### PR TITLE
Fix Matrix Spaces naming convention.

### DIFF
--- a/content/page/community/_index.md
+++ b/content/page/community/_index.md
@@ -12,7 +12,7 @@ The community is the most important part of Mwmbl, since everything we
 do depends on you. We aim to be one of the most friendly, diverse and
 welcoming communities on the internet.
 
-The main place we hang out is on [our Matrix server](https://matrix.to/#/#mwmbl:matrix.org)
+The main place we hang out is on [our Matrix Space](https://matrix.to/#/#mwmbl:matrix.org)
 but we also have a [Discord server](https://discord.gg/SJF689E3Rv),
 and a [YouTube channel](https://www.youtube.com/@mwmbl), along with a
 bunch of unmaintained socials...
@@ -54,7 +54,7 @@ we can free up resources on the central server.
 
 In order to run the crawler you need an API key.
 If you would like to run the crawler, please get in touch either on
-[our Matrix server](https://matrix.to/#/#mwmbl:matrix.org) or by
+[our Matrix Space](https://matrix.to/#/#mwmbl:matrix.org) or by
 sending an email to [info@mwmbl.org](mailto:info@mwmbl.org).
 
 Please give a few words about yourself and why you are interested in

--- a/content/page/working-groups/_index.md
+++ b/content/page/working-groups/_index.md
@@ -10,7 +10,7 @@ lastmod: "2022-12-01"
 
 If you want to help out with Mwmbl, this is the place to be! Working
 groups allow people to coordinate work on a specific aspect of
-Mwmbl. Get in touch on our [Matrix server](https://matrix.to/#/#mwmbl:matrix.org) 
+Mwmbl. Get in touch on our [Matrix Space](https://matrix.to/#/#mwmbl:matrix.org)
 and let us know how you'd like to be involved.
 
 


### PR DESCRIPTION
The term used for list of rooms and users in Matrix is called a "Space", so I fixed that.